### PR TITLE
[WIP] symbolic algebra functionality

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,5 +3,17 @@ uuid = "c7a6d0f7-daa6-4368-ba67-89ed64127c3b"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 version = "0.1.1"
 
+[deps]
+Dictionaries = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
+LightSumTypes = "f56206fc-af4c-5561-a72a-43fe2ca5a923"
+SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
+TermInterface = "8ea1fca8-c5ef-4a55-8b96-4e9afe9c9a3c"
+VectorInterface = "409d34a3-91d5-4945-b6ec-7529ddf182d8"
+
 [compat]
+Dictionaries = "0.4.4"
+LightSumTypes = "5.0.1"
+SymbolicUtils = "3.23.0"
+TermInterface = "2.0.0"
+VectorInterface = "0.5.0"
 julia = "1.10"

--- a/src/QuantumOperatorAlgebra.jl
+++ b/src/QuantumOperatorAlgebra.jl
@@ -1,10 +1,18 @@
 module QuantumOperatorAlgebra
 
-include("LazyApply/LazyApply.jl")
-# Make these available as `QuantumOperatorAlgebra.f`.
-using .LazyApply: coefficient, terms
+export Op, LocalOp
 
-include("op.jl")
-include("trotter.jl")
+using LightSumTypes
+using VectorInterface
+import VectorInterface: scalartype
+using TermInterface
+using Dictionaries
+
+import Base: +, *, -, /, \
+import Base: one, zero, isone, iszero
+import Base: show, show_unquoted
+
+include("symbolicalgebra/abstractalgebra.jl")
+include("symbolicalgebra/localalgebra.jl")
 
 end

--- a/src/symbolicalgebra/abstractalgebra.jl
+++ b/src/symbolicalgebra/abstractalgebra.jl
@@ -1,0 +1,223 @@
+"""
+    SymbolicAlgebra
+
+Abstract supertype for working with symbolic (operator) algebras.
+"""
+abstract type SymbolicAlgebra{T<:Number} end
+
+# Building blocks
+# ---------------
+struct Op{T<:Number,A}
+  id::A
+end
+
+struct Scaled{O,T<:Number}
+  op::O
+  scalar::T
+end
+
+struct Sum{O,T<:Number}
+  terms::Dictionary{O,T}
+  Sum{O,T}() where {O,T} = new{O,T}(Dictionary{O,T}())
+  Sum{O,T}(terms::Dictionary{O,T}) where {O,T} = new{O,T}(terms)
+end
+
+struct Prod{O}
+  factors::Vector{O}
+  Prod{O}() where {O} = new{O}(O[])
+  Prod{O}(factors::Vector{O}) where {O} = new{O}(factors)
+end
+
+struct Kron{O}
+  factors::Vector{O}
+  Kron{O}() where {O} = new{O}(O[])
+  Kron{O}(factors::Vector{O}) where {O} = new{O}(factors)
+end
+
+struct Fun{O}
+  f::Any
+  args::Vector{O}
+  Fun{O}(f) where {O} = new{O}(f, O[])
+  Fun{O}(f, args::Vector{O}) where {O} = new{O}(f, args)
+end
+
+
+# Properties
+# ----------
+VectorInterface.scalartype(::Type{<:SymbolicAlgebra{T}}) where {T} = scalartype(T)
+algebratype(a::SymbolicAlgebra) = algebratype(typeof(a))
+
+# Linear algebra
+# --------------
+
+# functionality to rewrite basic operations in terms of a more limited set
+(O::SymbolicAlgebra * λ::Number) = scale(O, λ)
+(λ::Number * O::SymbolicAlgebra) = scale(O, λ)
+(O::SymbolicAlgebra / λ::Number) = scale(O, inv(λ))
+(λ::Number \ O::SymbolicAlgebra) = scale(O, inv(λ))
+
++(O::SymbolicAlgebra) = scale(O, one(scalartype(O)))
+-(O::SymbolicAlgebra) = scale(O, -one(scalartype(O)))
+(O₁::SymbolicAlgebra + O₂::SymbolicAlgebra) = add(O₁, O₂)
+(O₁::SymbolicAlgebra - O₂::SymbolicAlgebra) = add(O₁, O₂, -one(scalartype(O₁)))
+# (O1::SymbolicAlgebra - O2::SymbolicAlgebra) = -(promote(O1, O2)...)
+
+# Show utility
+# ------------
+# functionality to display symbolic expressions
+# -> expressions show have two variants: show and show_unquoted to determine whether
+#    the expressions should be using parentheses
+
+"""
+    show_scaled(io::IO, operator, scalar)
+
+Utility function to display a scaled operator as `scalar * operator`.
+"""
+function show_scaled(io::IO, operator, scalar)
+  if isone(scalar)
+    show(io, operator)
+    return nothing
+  end
+
+  if isreal(scalar) && isone(abs(scalar))
+    print(io, '-')
+    show(io, operator)
+    return nothing
+  end
+
+  show_unquoted(io, scalar, 0, Base.operator_precedence(:*))
+  print(io, " * ")
+  show_unquoted(io, operator, 0, Base.operator_precedence(:*))
+
+  return nothing
+end
+
+"""
+    show_scaled_unquoted(io::IO, operator, scalar, indent::Int, precedence::Int)
+
+Utility function to display a scaled operator as `scalar * operator` within the context of
+a larger expression. This function will parenthesize the scaled operator if necessary, based
+on the relative precedence of `*` over `precedence`.
+
+See also `Base.show_unquoted` and `Base.operator_precedence`.
+"""
+function show_scaled_unquoted(io::IO, operator, scalar, indent::Int, precedence::Int)
+  should_parenthesize =
+    !isone(scalar) &&
+    (!isreal(scalar) || !isone(abs(scalar))) &&
+    Base.operator_precedence(:*) ≤ precedence
+
+  if should_parenthesize
+    print(io, "(")
+    show_scaled(io, operator, scalar)
+    print(io, ")")
+  else
+    show_scaled(io, operator, scalar)
+  end
+
+  return nothing
+end
+
+"""
+    show_summed(io::IO, operators, [scalars])
+
+Utility function to display a sum of operators as `operators[1] + operators[2] + ...`.
+"""
+function show_summed(io::IO, operators)
+  precedence = Base.operator_precedence(:+)
+  for (i, operator) in enumerate(operators)
+    if i == 1
+      show_unquoted(io, operator, 0, precedence)
+    else
+      print(io, " + ")
+      show_unquoted(io, operator, 0, precedence)
+    end
+  end
+  return nothing
+end
+
+function show_summed(io::IO, operators, scalars)
+  precedence = Base.operator_precedence(:+)
+
+  for (i, (operator, scalar)) in enumerate(zip(operators, scalars))
+    if i == 1
+      show_scaled_unquoted(io, operator, scalars[i], 0, precedence)
+      continue
+    end
+
+    # attempt to absorb the sign of the scalar
+    if isreal(scalar) && scalar < 0
+      print(io, " - ")
+      scalar = abs(scalar)
+    else
+      print(io, " + ")
+    end
+
+    show_scaled_unquoted(io, operator, scalar, 0, precedence)
+  end
+
+  return nothing
+end
+
+function show_summed_unquoted(io::IO, operators, indent::Int, precedence::Int)
+  if length(operators) == 1
+    show_unquoted(io, operators[1], indent, precedence)
+    return nothing
+  end
+
+  if Base.operator_precedence(:+) ≤ precedence
+    print(io, "(")
+    show_summed(io, operators)
+    print(io, ")")
+  else
+    show_summed(io, operators)
+  end
+
+  return nothing
+end
+function show_summed_unquoted(io::IO, operators, scalars, indent::Int, precedence::Int)
+  if length(operators) == 1
+    show_scaled_unquoted(io, only(operators), only(scalars)indent, precedence)
+    return nothing
+  end
+
+  if Base.operator_precedence(:+) ≤ precedence
+    print(io, "(")
+    show_summed(io, operators, scalars)
+    print(io, ")")
+  else
+    show_summed(io, operators, scalars)
+  end
+
+  return nothing
+end
+
+function show_product(io::IO, factors)
+  precedence = Base.operator_precedence(:*)
+
+  for (i, factor) in enumerate(factors)
+    if i == 1
+      show_unquoted(io, factor, 0, precedence)
+    else
+      print(io, " * ")
+      show_unquoted(io, factor, 0, precedence)
+    end
+  end
+end
+
+function show_product_unquoted(io::IO, factors, indent::Int, precedence::Int)
+  if length(operators) == 1
+    show_unquoted(io, only(factors), indent, precedence)
+    return nothing
+  end
+
+  if Base.operator_precedence(:*) ≤ precedence
+    print(io, "(")
+    show_prod(io, factors)
+    print(io, ")")
+  else
+    show_prod(io, factors)
+  end
+
+  return nothing
+end

--- a/src/symbolicalgebra/localalgebra.jl
+++ b/src/symbolicalgebra/localalgebra.jl
@@ -1,0 +1,376 @@
+@doc """
+    LocalOp{T,A}
+
+Symbolic operator algebra for representing local operators acting on a a number of sites.
+The type parameter `T` denotes the scalar type of the operator, while `A` denotes the algebra.
+""" LocalOp
+
+@sumtype LocalOp{T,A}(
+  Op{T,A},
+  Scaled{LocalOp{T,A},T},
+  Sum{LocalOp{T,A},T},
+  Prod{LocalOp{T,A}},
+  Kron{LocalOp{T,A}},
+  Fun{LocalOp{T,A}},
+) <: SymbolicAlgebra{T}
+
+const VariantTypes = Union{Op,Scaled,Sum,Prod,Kron,Fun}
+
+# Properties
+# ----------
+algebratype(::Type{LocalOp{T,A}}) where {T,A} = A
+
+"""
+    support(O::LocalOp) -> Int
+
+Return the support of the operator `O`, defined as the number of sites on which it acts.
+For composite objects that arent `Kron`, this property must always be homogenous.
+"""
+support(O::LocalOp) = support(variant(O))
+support(::Op) = 1
+support(o::Scaled) = support(o.op)
+support(o::Sum) = support(first(keys(o.terms)))
+support(o::Prod) = support(first(o.factors))
+support(o::Kron) = sum(support, o.factors)
+
+function checksupport(O₁, O₂)
+  return checksupport(Bool, O₁, O₂) ||
+         throw(ArgumentError("Operators act on different spaces"))
+end
+function checksupport(::Type{Bool}, O₁::LocalOp, O₂::LocalOp)
+  return support(O₁) == support(O₂) && algebratype(O₁) == algebratype(O₂)
+end
+
+# VectorInterface
+# ---------------
+function VectorInterface.scale(O::LocalOp, λ::Number)
+  T′ = VectorInterface.promote_scale(scalartype(O), scalartype(λ))
+  TO = LocalOp{T′,algebratype(O)}
+  return TO(Scaled{TO,T′}(O, λ))
+end
+
+function VectorInterface.add(O₁::LocalOp, O₂::LocalOp, α::Number, β::Number)
+  checksupport(O₁, O₂)
+  T′ = VectorInterface.promote_add(
+    scalartype(O₁), scalartype(O₂), scalartype(α), scalartype(β)
+  )
+  TO = LocalOp{T′,algebratype(O₁)}
+
+  res = Sum{TO,T′}()
+
+  # add terms from O₁
+  if !iszero(β)
+    o₁ = variant(O₁)
+    if o₁ isa Sum
+      for (o, λ) in pairs(o₁.terms)
+        insert!(res.terms, o, T′(β * λ))
+      end
+    elseif o₁ isa Scaled
+      insert!(res.terms, o₁.op, T′(β * o₁.scalar))
+    else
+      insert!(res.terms, O₁, T′(β))
+    end
+  end
+
+  # add terms from O₂
+  if !iszero(α)
+    o₂ = variant(O₂)
+    if o₂ isa Sum
+      for (o, λ) in pairs(o₂.terms)
+        setwith!(+, res.terms, o, T′(α * λ))
+      end
+    elseif o₂ isa Scaled
+      setwith!(+, res.terms, o₂.op, T′(α * o₂.scalar))
+    else
+      setwith!(+, res.terms, O₂, T′(α))
+    end
+  end
+
+  return TO(res)
+end
+
+# LinearAlgebra
+# -------------
+function (O₁::LocalOp * O₂::LocalOp)
+  checksupport(O₁, O₂)
+  T = Base.promote_op(*, scalartype(O₁), scalartype(O₂))
+  TO = LocalOp{T,algebratype(O₁)}
+
+  res = Prod{TO}()
+
+  # add factors from O₁
+  o₁ = variant(O₁)
+  if o₁ isa Prod
+    append!(res.factors, o₁.factors)
+  else
+    push!(res.factors, O₁)
+  end
+
+  # add factors from O₂
+  o₂ = variant(O₂)
+  if o₂ isa Prod
+    append!(res.factors, o₂.factors)
+  else
+    push!(res.factors, O₂)
+  end
+
+  return TO(res)
+end
+
+function (O₁::LocalOp ⊗ O₂::LocalOp)
+  algebratype(O₁) == algebratype(O₂) ||
+    throw(ArgumentError("Operators act on different spaces"))
+  T = Base.promote_op(*, scalartype(O₁), scalartype(O₂))
+  TO = LocalOp{T,algebratype(O₁)}
+
+  res = Kron{TO}()
+  # add factors from O₁
+  o₁ = variant(O₁)
+  if o₁ isa Kron
+    append!(res.factors, o₁.factors)
+  else
+    push!(res.factors, O₁)
+  end
+
+  # add factors from O₂
+  o₂ = variant(O₂)
+  if o₂ isa Kron
+    append!(res.factors, o₂.factors)
+  else
+    push!(res.factors, O₂)
+  end
+
+  return TO(res)
+end
+
+# Sorting
+# -------
+# dispatch to variants:
+Base.isless(O₁::LocalOp, O₂::LocalOp) = isless(variant(O₁), variant(O₂))
+
+# order by types
+const _order = (:Op, :Kron, :Scaled, :Sum, :Prod, :Fun)
+
+for (i, O₁) in enumerate(_order)
+  for (j, O₂) in enumerate(_order)
+    i == j && continue
+    @eval Base.isless(::$O₁, ::$O₂) = $(i < j)
+  end
+end
+
+# then sort by inner data
+Base.isless(O₁::Op, O₂::Op) = isless(O₁.id, O₂.id)
+Base.isless(O₁::Scaled, O₂::Scaled) = isless((O₁.op, O₁.λ), (O₂.op, O₂.λ)) # inherit from Tuple
+Base.isless(O₁::Sum, O₂::Sum) = isless(O₁.terms, O₂.terms) # inherit from Dictionary
+Base.isless(O₁::Prod, O₂::Prod) = isless(O₁.factors, O₂.factors) # inherit from Vector
+Base.isless(O₁::Kron, O₂::Kron) = isless(O₁.factors, O₂.factors) # inherit from Vector
+
+# Equality
+# --------
+# dispatch to variants:
+Base.:(==)(O₁::LocalOp, O₂::LocalOp) = variant(O₁) == variant(O₂)
+
+# order by types
+Base.:(==)(O₁::VariantTypes, O₂::VariantTypes) = false
+Base.:(==)(O₁::Op, O₂::Op) = O₁.id == O₂.id
+Base.:(==)(O₁::Scaled, O₂::Scaled) = (O₁.op, O₁.scalar) == (O₂.op, O₂.scalar)
+Base.:(==)(O₁::Sum, O₂::Sum) = O₁.terms == O₂.terms
+Base.:(==)(O₁::Prod, O₂::Prod) = O₁.factors == O₂.factors
+Base.:(==)(O₁::Kron, O₂::Kron) = O₁.factors == O₂.factors
+Base.:(==)(O₁::Fun, O₂::Fun) = O₁.f == O₂.f && O₁.args == O₂.args
+
+# TermInterface
+# -------------
+TermInterface.isexpr(O::LocalOp) = TermInterface.isexpr(variant(O))
+TermInterface.isexpr(::Op) = false
+TermInterface.isexpr(::Scaled) = true
+TermInterface.isexpr(::Sum) = true
+TermInterface.isexpr(::Prod) = true
+TermInterface.isexpr(::Kron) = true
+TermInterface.isexpr(::Fun) = true
+
+TermInterface.head(O::LocalOp) = TermInterface.head(variant(O))
+TermInterface.head(::Scaled) = :(*)
+TermInterface.head(::Sum) = :(+)
+TermInterface.head(::Prod) = :(*)
+TermInterface.head(::Kron) = :(⊗)
+TermInterface.head(o::Fun) = o.f
+
+TermInterface.children(O::LocalOp) = TermInterface.children(variant(O))
+TermInterface.children(o::Scaled) = (o.op, o.scalar)
+TermInterface.children(o::Sum) = [o * λ for (o, λ) in pairs(o.terms)]
+TermInterface.children(o::Prod) = o.factors
+TermInterface.children(o::Kron) = o.factors
+TermInterface.children(o::Fun) = o.args
+
+TermInterface.iscall(O::LocalOp) = TermInterface.iscall(variant(O))
+TermInterface.iscall(::Op) = false
+TermInterface.iscall(::Scaled) = true
+TermInterface.iscall(::Sum) = true
+TermInterface.iscall(::Prod) = true
+TermInterface.iscall(::Kron) = true
+TermInterface.iscall(::Fun) = true
+
+TermInterface.operation(O::LocalOp) = TermInterface.operation(variant(O))
+TermInterface.operation(::Scaled) = (*)
+TermInterface.operation(::Sum) = (+)
+TermInterface.operation(::Prod) = (*)
+TermInterface.operation(::Kron) = (⊗)
+TermInterface.operation(o::Fun) = o.f
+
+TermInterface.arguments(O::LocalOp) = TermInterface.arguments(variant(O))
+TermInterface.arguments(o::Scaled) = (o.op, o.scalar)
+TermInterface.arguments(o::Sum) = [o * λ for (o, λ) in pairs(o.terms)]
+TermInterface.arguments(o::Prod) = o.factors
+TermInterface.arguments(o::Kron) = o.factors
+TermInterface.arguments(o::Fun) = o.args
+
+function TermInterface.maketerm(::Type{<:LocalOp}, ::typeof(+), args, metadata=nothing)
+  @debug "maketerm(+)" args
+  return +(args...)
+end
+
+function TermInterface.maketerm(::Type{<:LocalOp}, ::typeof(*), args, metadata=nothing)
+  return *(args...)
+  T = mapreduce(scalartype, (x, y) -> Base.promote_op(*, x, y), args; init=Bool)
+  if length(args) == 2 && args[1] isa LocalOp && args[2] isa Number
+    A = algebratype(args[1])
+    TO = LocalOp{T,A}
+    return TO(Scaled{TO,T}(args[1], args[2]))
+  end
+
+  # TODO: rewrite check
+  @assert allequal(algebratype, args)
+  A = algebratype(first(args))
+  TO = LocalOp{T,A}
+  res = Prod{TO}(args)
+  return TO(res)
+end
+
+function TermInterface.maketerm(::Type{<:LocalOp}, ::typeof(⊗), args, metadata=nothing)
+  return ⊗(args...)
+  T = mapreduce(scalartype, (x, y) -> Base.promote_op(*, x, y), args; init=Bool)
+  @assert allequal(algebratype, args)
+  A = algebratype(first(args))
+  TO = LocalOp{T,A}
+  res = Kron{TO}(args)
+  return TO(res)
+end
+
+function TermInterface.maketerm(::Type{<:LocalOp}, f::Function, args, metadata=nothing)
+  T = mapreduce(scalartype, (x, y) -> Base.promote_op(*, x, y), args; init=Bool)
+  @assert allequal(algebratype, args)
+  A = algebratype(first(args))
+  TO = LocalOp{T,A}
+  res = Fun{TO}(f, args)
+  return TO(res)
+end
+
+# Show
+# ----
+
+function Base.show(io::IO, O::LocalOp)
+  if !(get(io, :typeinfo, Any) <: LocalOp)
+    summary(io, O)
+    println(io, ":")
+    print(io, " ")
+  end
+
+  ctx = IOContext(io, :typeinfo => typeof(O))
+  show(ctx, variant(O))
+  return nothing
+end
+
+function Base.show_unquoted(io::IO, O::LocalOp, indent::Int, precedence::Int)
+  if !(get(io, :typeinfo, Any) <: LocalOp)
+    summary(io, O)
+    println(io, ":")
+    print(io, " ")
+  end
+
+  show_unquoted(IOContext(io, :typeinfo => typeof(O)), variant(O), indent, precedence)
+  return nothing
+end
+
+function Base.show(io::IO, O::Op{T,A}) where {T,A}
+  if get(io, :typeinfo, Any) <: LocalOp
+    print(io, "Op(")
+    show(IOContext(io, :typeinfo => A), O.id)
+    print(io, ")")
+  else
+    show(io, typeof(O))
+    print(io, "(")
+    show(IOContext(io, :typeinfo => A), O.id)
+    print(io, ")")
+  end
+  return nothing
+end
+
+function Base.show(io::IO, O::Scaled{LocalOp{T,A},T}) where {T,A}
+  if !(get(io, :typeinfo, Any) <: LocalOp{T,A})
+    print(io, typeof(O))
+    println(io, ":")
+    print(io, " ")
+  end
+
+  show_scaled(io, O.op, O.scalar)
+  return nothing
+end
+
+function Base.show(io::IO, O::Sum{LocalOp{T,A},T}) where {T,A}
+  if !(get(io, :typeinfo, Any) <: LocalOp{T,A})
+    print(io, typeof(O))
+    println(io, ":")
+    print(io, " ")
+  end
+
+  show_summed(io, collect(keys(O.terms)), collect(values(O.terms)))
+  return nothing
+end
+function Base.show_unquoted(io::IO, O::Sum, indent::Int, precedence::Int)
+  if !(get(io, :typeinfo, Any) <: LocalOp)
+    print(io, typeof(O))
+    println(io, ":")
+    print(io, " ")
+  end
+
+  show_summed_unquoted(
+    io, collect(keys(O.terms)), collect(values(O.terms)), indent, precedence
+  )
+  return nothing
+end
+
+function Base.show(io::IO, O::Prod{LocalOp{T,A}}) where {T,A}
+  if !(get(io, :typeinfo, Any) <: LocalOp{T,A})
+    print(io, typeof(O))
+    println(io, ":")
+    print(io, " ")
+  end
+
+  show_product(io, O.factors)
+  return nothing
+end
+
+function Base.show_unquoted(
+  io::IO, O::Prod{LocalOp{T,A}}, indent::Int, precedence::Int
+) where {T,A}
+  if !(get(io, :typeinfo, Any) <: LocalOp{T,A})
+    print(io, typeof(O))
+    println(io, ":")
+    print(io, " ")
+  end
+
+  show_product_unquoted(io, O.factors, indent, precedence)
+  return nothing
+end
+
+function Base.show(io::IO, O::Kron{LocalOp{T,A}}) where {T,A}
+  if !(get(io, :typeinfo, Any) <: LocalOp{T,A})
+    print(io, typeof(O))
+    println(io, ":")
+    print(io, " ")
+  end
+
+  show_kron(io, O.factors)
+  return nothing
+end


### PR DESCRIPTION
This is a very much WIP PR that starts showing some of the work on symbolic operator algebras.

Here, the main focus is on laying some ground work for two specific algebra types:
- a *local* algebra: this is supposed to be a symbolic version of local operators: operators that act on a local hilbert space (or a number of copies thereof), ie without knowledge of the geometry of the sites it is acting on. 
- a *global* algebra: this is supposed to be a symbolic version of operators acting on the full hilbert space, ie with knowledge of the lattice etc. Here, operators are assumed to be acting non-trivially on a subset of the sites, and the identities can be left implicit.

### To do

**Build local operator types**
- [x] operators, sums, products, kron, functions, ...
- [x] linear algebra
- [x] `Base.show`
- [x] Compatibility with `SymbolicUtils.rewrite`
- [ ] Define simplification rewriting rules

**Global operator types**
- [ ] Build global operator types
- [ ] Minimize code duplication between the two

- [ ] Testing
- [ ] Benchmarking